### PR TITLE
bump version to 0.9.1

### DIFF
--- a/lib/pronto/style_cop/version.rb
+++ b/lib/pronto/style_cop/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module StyleCopVersion
-    VERSION = '0.9.0'.freeze
+    VERSION = '0.9.1'.freeze
   end
 end


### PR DESCRIPTION
bump version to 0.9.1
fixed
- https://github.com/ajapon88/pronto-style_cop/pull/1: definitionsが未定義の時にStyleCopでエラーになっていたのを修正