### PR TITLE
rename environment PRONT_STYLECOP_SETTINGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Pronto runner for StyleCop, csharp code analyzer. [What is Pronto?](https://gith
 ## Configuration
 
 Configuring StyleCop via Settings.StyleCop will work just fine with pronto-style_cop.
-You can also specify a custom `Settings.StyleCop` location with the environment variable `STYLECOP_SETTINGS`
+You can also specify a custom `Settings.StyleCop` location with the environment variable `PRONTO_STYLECOP_SETTINGS`
 
 ## Installation StyleCopCLI
 

--- a/lib/pronto/style_cop.rb
+++ b/lib/pronto/style_cop.rb
@@ -57,7 +57,14 @@ module Pronto
     end
 
     def settings
-      @settings ||= ENV.fetch('STYLECOP_SETTINGS', nil) || (File.exist?('./Settings.StyleCop') ? './Settings.StyleCop' : nil)
+      @settings ||= begin
+        puts "deprecation environment variable 'STYLECOP_SETTINGS'" if ENV.key?('STYLECOP_SETTINGS')
+
+        settigns = ENV.fetch('PRONTO_STYLECOP_SETTINGS', nil)
+        settigns = ENV.fetch('STYLECOP_SETTINGS', nil) if settigns.nil? # deprecation
+        settigns = './Settings.StyleCop' if settigns.nil? && File.exist?('./Settings.StyleCop')
+        settigns
+      end
     end
 
     def definitions

--- a/spec/pronto/style_cop_spec.rb
+++ b/spec/pronto/style_cop_spec.rb
@@ -18,9 +18,9 @@ module Pronto
 
     describe '#options' do
       let(:definition) { [] }
-      let(:stylecop_settings) { nil }
       subject { style_cop.send(:stylecop_options, definition) }
-      before { stub_const('ENV', 'STYLECOP_SETTINGS' => stylecop_settings) }
+      before { stub_const('ENV', 'STYLECOP_SETTINGS' => nil) }
+      before { stub_const('ENV', 'PRONTO_STYLECOP_SETTINGS' => nil) }
 
       context 'option definition to flags' do
         let(:definition) { ['DEBUG'] }
@@ -33,8 +33,19 @@ module Pronto
       end
 
       context 'from config file env variable' do
-        let(:stylecop_settings) { 'Settings.StyleCop' }
-        it { should == ["-set '#{stylecop_settings}'"] }
+        before { stub_const('ENV', 'STYLECOP_SETTINGS' => 'Settings.StyleCop') }
+        it { should == ["-set 'Settings.StyleCop'"] }
+      end
+
+      context 'from config file env variable' do
+        before { stub_const('ENV', 'PRONTO_STYLECOP_SETTINGS' => 'Settings.StyleCop') }
+        it { should == ["-set 'Settings.StyleCop'"] }
+      end
+
+      context 'from config file env variable' do
+        before { stub_const('ENV', 'STYLECOP_SETTINGS' => 'Settings.StyleCop') }
+        before { stub_const('ENV', 'PRONTO_STYLECOP_SETTINGS' => 'ProntoSettings.StyleCop') }
+        it { should == ["-set 'ProntoSettings.StyleCop'"] }
       end
     end
     describe '#parallel' do


### PR DESCRIPTION
`Settings.StyleCop` 指定環境変数として `PRONTO_STYLECOP_SETTINGS` を追加
`STYLECOP_SETTINGS` はdeprecation